### PR TITLE
Create Wifi Setup Instructions

### DIFF
--- a/wifi-setup.ipynb
+++ b/wifi-setup.ipynb
@@ -1,0 +1,235 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "61765a8a",
+   "metadata": {},
+   "source": [
+    "# Wifi Setup\n",
+    "\n",
+    "This notebook walks through how to setup for connection currently (and in the future, after reboots) to a wifi network.\n",
+    "\n",
+    "This notebook assumes you have a wifi dongle plugged into your board."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65a42d5e",
+   "metadata": {},
+   "source": [
+    "#### Helper Functions\n",
+    "Below are helper and library imports that we will use to setup the wifi."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "9261d799",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import subprocess as sp\n",
+    "import json, os\n",
+    "\n",
+    "def get_interface():\n",
+    "    interface = sp.getoutput(\"ifconfig | awk '$1 ~ /^wl/ {print $1}' | rev | cut -c 2- | rev\")\n",
+    "    return interface\n",
+    "\n",
+    "def get_ip(interface: str):\n",
+    "    ip_addr = sp.getoutput(f\"ifconfig \" + interface + \" | grep 'inet ' | cut -f1 | awk '{ print $2 }'\")\n",
+    "    return ip_addr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be8dd436",
+   "metadata": {},
+   "source": [
+    "#### Please enter some information about your wifi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "bf59efb7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Type in the SSID:PYNQ3-1\n",
+      "Type in the password:Hackathon!1\n"
+     ]
+    }
+   ],
+   "source": [
+    "ssid = input(\"Type in the SSID:\")\n",
+    "pwd = input(\"Type in the password:\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "973643b3",
+   "metadata": {},
+   "source": [
+    "#### Now we will connect the board to your wifi\n",
+    "\n",
+    "Note that you may see a lot of output!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "ceed78f4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running: cd /home/ubuntu/kria-wifi && sudo ./setup.sh 'PYNQ3-1' 'Hackathon!1'\n",
+      "Setting up wifi for interface\n",
+      "ESSID PYNQ3-1  PASSPHRASE Hackathon!1\n",
+      "#!/usr/bin/bash\n",
+      "\n",
+      "sudo /sbin/wpa_supplicant -u -s -c /etc/wpa_supplicant.conf -i \"$(ifconfig | awk '$1 ~ /^wl/ {print $1}' | rev | cut -c 2- | rev)\"\n",
+      "[Unit]\n",
+      "Description=WPA supplicant\n",
+      "Before=network.target\n",
+      "After=dbus.service\n",
+      "Wants=network.target\n",
+      "IgnoreOnIsolate=true\n",
+      "\n",
+      "[Service]\n",
+      "Type=dbus\n",
+      "BusName=fi.w1.wpa_supplicant1\n",
+      "ExecStart=/usr/bin/wifi.sh\n",
+      "Restart=always\n",
+      "ExecReload=/bin/kill -HUP \n",
+      "\n",
+      "[Install]\n",
+      "WantedBy=multi-user.target\n",
+      "# Alias=dbus-fi.w1.wpa_supplicant1.service\n",
+      "[Unit]\n",
+      "Description= DHCP Client\n",
+      "Before=network.target\n",
+      "\n",
+      "[Service]\n",
+      "Type=forking\n",
+      "ExecStart=/sbin/dhclient \"$(ifconfig | awk '$1 ~ /^wl/ {print $1}' | rev | cut -c 2- | rev)\" -v\n",
+      "ExecStop=/sbin/dhclient \"$(ifconfig | awk '$1 ~ /^wl/ {print $1}' | rev | cut -c 2- | rev)\" -r\n",
+      "Restart=always\n",
+      "\n",
+      "[Install]\n",
+      "WantedBy=multi-user.target\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Call the network config script\n",
+    "cmd = \"cd /home/ubuntu/kria-wifi && sudo ./setup.sh '\" + ssid + \"' '\" + pwd + \"'\"\n",
+    "print(\"Running: \" + cmd)\n",
+    "output = sp.getoutput(cmd)\n",
+    "lines = output.split(\"\\n\")\n",
+    "for l in lines:\n",
+    "    print(l)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5ea2721",
+   "metadata": {},
+   "source": [
+    "#### Check Connectivity and Get IP Address and Interface\n",
+    "\n",
+    "Note that if you got an error here, you probably did not connect correctly for some reason and should troubleshoot! You may also need to a wait a minute before an IP address is assigned."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "7fd4e344",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "My interface is wlx08beac12c5b0 and my IP is 192.168.20.23\n"
+     ]
+    }
+   ],
+   "source": [
+    "my_interface = get_interface()\n",
+    "my_ip = get_ip(my_interface)\n",
+    "print(f\"My interface is {my_interface} and my IP is {my_ip}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02e327e8",
+   "metadata": {},
+   "source": [
+    "# OLED IP Address Display Setup\n",
+    "\n",
+    "Now we will install a service that will print the IP address assigned to the wifi interface every time the board boots up, assuming there is an OLED display attached.\n",
+    "\n",
+    "Please note you only need to do this once per board setup, not once per wifi setup!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "2bb7cc11",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running: cd /home/ubuntu/show-kria-ip && sudo ./setup.sh\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "cmd = \"cd /home/ubuntu/show-kria-ip && sudo ./setup.sh\"\n",
+    "print(\"Running: \" + cmd)\n",
+    "output = sp.getoutput(cmd)\n",
+    "lines = output.split(\"\\n\")\n",
+    "for l in lines:\n",
+    "    print(l)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea7fac0f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds a new notebook which is aimed to help setup boards to connect to new wifi networks, as well as set up services needed to display assigned IP addresses on an OLED display upon boot using the [show-kria-ip repo](https://github.com/hunhoffe/show-kria-ip).